### PR TITLE
Changes input type from 'text' to 'number'

### DIFF
--- a/frontend/src/components/Form/Form.js
+++ b/frontend/src/components/Form/Form.js
@@ -8,7 +8,7 @@ function Form (props) {
             <div className="form-section">
               <div className="form-group">
                 <label>How many paragraphs do you want?</label>
-                <input type="text" placeholder="# Here" ref={ props.getRef }/>
+                <input type="number" placeholder="# Here" ref={ props.getRef }/>
               </div>
               <div className="form-group">
                 <div onClick={ props.handleSubmit } className="btn">Get It</div>


### PR DESCRIPTION
I put 'ass' as the number of paragraphs and it broke because `NaN` was being sent to the API. This solves that particular issue without having to add your own form validation